### PR TITLE
fix: update AG-UI packages to 0.0.43 to match server version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,9 +12,9 @@
     }
   },
   "dependencies": {
-    "@ag-ui/client": "^0.0.39",
-    "@ag-ui/core": "^0.0.39",
-    "@ag-ui/encoder": "^0.0.39",
-    "@ag-ui/proto": "^0.0.39"
+    "@ag-ui/client": "^0.0.43",
+    "@ag-ui/core": "^0.0.43",
+    "@ag-ui/encoder": "^0.0.43",
+    "@ag-ui/proto": "^0.0.43"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,43 +80,43 @@ importers:
   packages/core:
     dependencies:
       '@ag-ui/client':
-        specifier: ^0.0.39
-        version: 0.0.39
+        specifier: ^0.0.43
+        version: 0.0.43
       '@ag-ui/core':
-        specifier: ^0.0.39
-        version: 0.0.39
+        specifier: ^0.0.43
+        version: 0.0.43
       '@ag-ui/encoder':
-        specifier: ^0.0.39
-        version: 0.0.39
+        specifier: ^0.0.43
+        version: 0.0.43
       '@ag-ui/proto':
-        specifier: ^0.0.39
-        version: 0.0.39
+        specifier: ^0.0.43
+        version: 0.0.43
 
   packages/fb-messenger: {}
 
 packages:
-  '@ag-ui/client@0.0.39':
+  '@ag-ui/client@0.0.43':
     resolution:
       {
-        integrity: sha512-VHusZRv0dBtxqKSh/fcLbS/txUpXuE68/2s8RiMoav1snEDonwPGNjvOdE15WResgnlEWPU5qPuSgPykvt2/+A==,
+        integrity: sha512-150Y3TX+k83qvtmp4bTxmPW0Xu7to2y5vlhD8s5gof5/fxMdxybM1ieZazN7OIWU0nCK/hvhA+bVC7mmyby3gw==,
       }
 
-  '@ag-ui/core@0.0.39':
+  '@ag-ui/core@0.0.43':
     resolution:
       {
-        integrity: sha512-T5Hp4oFkQ+H5MynWAvSwrX/rNYJOD+PJ4qPQ0o771oSZQAxoIvDDft47Cx5wRyBNNLXAe1RWqJjfWUUwJFNKqA==,
+        integrity: sha512-/T7kKwPAhtriFFiv3YxZ0yAzMHoY8a8I5UKzhPzwW934h92c6RJ54N93yb9PAqdX3XjCPId0C5gIBHb6QbeR3Q==,
       }
 
-  '@ag-ui/encoder@0.0.39':
+  '@ag-ui/encoder@0.0.43':
     resolution:
       {
-        integrity: sha512-6fsoFwPWkStK7Uyj3pwBn7+aQjUWf7pbDTSI43cD53sBLvTr5oEFNnoKOzRfC5UqvHc4JjUIuLKPQyjHRwWg4g==,
+        integrity: sha512-0b7VXFW5KMctdWsGFQEkbIU2gY/tUv0eWBbMchIvjiIS1aHxdGTB6NXHXJzGvDcXEb3urkIvVIFGvpk0WOUhVw==,
       }
 
-  '@ag-ui/proto@0.0.39':
+  '@ag-ui/proto@0.0.43':
     resolution:
       {
-        integrity: sha512-xlj/PzZHkJ3CgoQC5QP9g7DEl/78wUK1+A2rdkoLKoNAMOkM2g6jKw0N88iFIh5GZhtiCNN2wb8XwRWPYx9XQQ==,
+        integrity: sha512-JcGjwMyxd5KiRTVi3158eByPXm9lKDRMIApYgSlzhXpBwyfpub8waGFnEWqjE3U+gA1LaZHiVMIfD5NCVYj4WQ==,
       }
 
   '@bufbuild/protobuf@2.9.0':
@@ -1454,6 +1454,12 @@ packages:
         integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==,
       }
     engines: { node: '>=18' }
+
+  compare-versions@6.1.1:
+    resolution:
+      {
+        integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==,
+      }
 
   concat-map@0.0.1:
     resolution:
@@ -3954,31 +3960,32 @@ packages:
       }
 
 snapshots:
-  '@ag-ui/client@0.0.39':
+  '@ag-ui/client@0.0.43':
     dependencies:
-      '@ag-ui/core': 0.0.39
-      '@ag-ui/encoder': 0.0.39
-      '@ag-ui/proto': 0.0.39
+      '@ag-ui/core': 0.0.43
+      '@ag-ui/encoder': 0.0.43
+      '@ag-ui/proto': 0.0.43
       '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
       fast-json-patch: 3.1.1
       rxjs: 7.8.1
       untruncate-json: 0.0.1
       uuid: 11.1.0
       zod: 3.25.76
 
-  '@ag-ui/core@0.0.39':
+  '@ag-ui/core@0.0.43':
     dependencies:
       rxjs: 7.8.1
       zod: 3.25.76
 
-  '@ag-ui/encoder@0.0.39':
+  '@ag-ui/encoder@0.0.43':
     dependencies:
-      '@ag-ui/core': 0.0.39
-      '@ag-ui/proto': 0.0.39
+      '@ag-ui/core': 0.0.43
+      '@ag-ui/proto': 0.0.43
 
-  '@ag-ui/proto@0.0.39':
+  '@ag-ui/proto@0.0.43':
     dependencies:
-      '@ag-ui/core': 0.0.39
+      '@ag-ui/core': 0.0.43
       '@bufbuild/protobuf': 2.9.0
       '@protobuf-ts/protoc': 2.11.1
 
@@ -4660,6 +4667,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@13.1.0: {}
+
+  compare-versions@6.1.1: {}
 
   concat-map@0.0.1: {}
 


### PR DESCRIPTION
The client was using @ag-ui/* 0.0.39 but the openclaw server runs 0.0.43, causing Zod validation errors for missing messageId fields.

https://claude.ai/code/session_012diRkjkTmZDSdBj27n9QuL